### PR TITLE
Added the capability to pass in a context when checking if a feature …

### DIFF
--- a/Microsoft.FeatureManagement.sln
+++ b/Microsoft.FeatureManagement.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28119.50
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29011.400
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FeatureFlagDemo", "examples\FeatureFlagDemo\FeatureFlagDemo.csproj", "{E58A64A6-BE10-4D7A-AAB8-C3E2925CB32F}"
 EndProject
@@ -12,6 +12,10 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{8ED6FFEE-4037-49A2-9709-BC519C104A90}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.FeatureManagement.AspNetCore", "src\Microsoft.FeatureManagement.AspNetCore\Microsoft.FeatureManagement.AspNetCore.csproj", "{CFD3E549-2E24-490D-A7F6-F95E56A81092}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{FB5C34DF-695C-4DF9-8AED-B3EA2516EA72}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp", "examples\ConsoleApp\ConsoleApp.csproj", "{E50FB931-7A42-440E-AC47-B8DFE5E15394}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,12 +39,18 @@ Global
 		{CFD3E549-2E24-490D-A7F6-F95E56A81092}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CFD3E549-2E24-490D-A7F6-F95E56A81092}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CFD3E549-2E24-490D-A7F6-F95E56A81092}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{E58A64A6-BE10-4D7A-AAB8-C3E2925CB32F} = {FB5C34DF-695C-4DF9-8AED-B3EA2516EA72}
 		{FDBB27BA-C5BA-48A7-BA9B-63159943EA9F} = {8ED6FFEE-4037-49A2-9709-BC519C104A90}
+		{E50FB931-7A42-440E-AC47-B8DFE5E15394} = {FB5C34DF-695C-4DF9-8AED-B3EA2516EA72}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {84DA6C54-F140-4518-A1B4-E4CF42117FBD}

--- a/examples/ConsoleApp/AccountServiceContext.cs
+++ b/examples/ConsoleApp/AccountServiceContext.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Consoto.Banking.AccountService.FeatureFilters;
+
+namespace Consoto.Banking.AccountService
+{
+    class AccountServiceContext : IAccountContext
+    {
+        public string AccountId { get; set; }
+    }
+}

--- a/examples/ConsoleApp/ConsoleApp.csproj
+++ b/examples/ConsoleApp/ConsoleApp.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>Consoto.Banking.AccountService</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.FeatureManagement\Microsoft.FeatureManagement.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
+++ b/examples/ConsoleApp/FeatureFilters/AccountIdFilter.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Consoto.Banking.AccountService.FeatureFilters;
+using Microsoft.Extensions.Configuration;
+using Microsoft.FeatureManagement;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Consoto.Banking.AccountService.FeatureManagement
+{
+    /// <summary>
+    /// A filter that uses the feature management context to ensure that the current task has the notion of an account id, and that the account id is allowed.
+    /// This filter will only be executed if an object implementing <see cref="IAccountContext"/> is passed in during feature evaluation.
+    /// </summary>
+    [FilterAlias("AccountId")]
+    class AccountIdFilter : IContextualFeatureFilter<IAccountContext>
+    {
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureEvaluationContext, IAccountContext accountContext)
+        {
+            if (string.IsNullOrEmpty(accountContext?.AccountId))
+            {
+                throw new ArgumentNullException(nameof(accountContext));
+            }
+
+            var allowedAccounts = new List<string>();
+
+            featureEvaluationContext.Parameters.Bind("AllowedAccounts", allowedAccounts);
+
+            return Task.FromResult(allowedAccounts.Contains(accountContext.AccountId));
+        }
+    }
+}

--- a/examples/ConsoleApp/FeatureFilters/IAccountContext.cs
+++ b/examples/ConsoleApp/FeatureFilters/IAccountContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Consoto.Banking.AccountService.FeatureFilters
+{
+    public interface IAccountContext
+    {
+        string AccountId { get; }
+    }
+}

--- a/examples/ConsoleApp/Program.cs
+++ b/examples/ConsoleApp/Program.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Consoto.Banking.AccountService.FeatureManagement;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.FeatureManagement;
+using Microsoft.FeatureManagement.FeatureFilters;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Consoto.Banking.AccountService
+{
+    class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            //
+            // Setup configuration
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .Build();
+
+            //
+            // Setup application services + feature management
+            IServiceCollection services = new ServiceCollection();
+
+            services.AddSingleton(configuration)
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<PercentageFilter>()
+                    .AddFeatureFilter<AccountIdFilter>();
+
+            //
+            // Get the feature manager from application services
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            IFeatureManager featureManager = serviceProvider.GetRequiredService<IFeatureManager>();
+
+            var accounts = new List<string>()
+            {
+                "abc",
+                "adef",
+                "abcdefghijklmnopqrstuvwxyz"
+            };
+
+            //
+            // Mimic work items in a task-driven console application
+            foreach (var account in accounts)
+            {
+                const string FeatureName = "Beta";
+
+                //
+                // Check if feature enabled
+                //
+                var accountServiceContext = new AccountServiceContext
+                {
+                    AccountId = account
+                };
+
+                bool enabled = await featureManager.IsEnabledAsync(FeatureName, accountServiceContext);
+
+                //
+                // Output results
+                Console.WriteLine($"The {FeatureName} feature is {(enabled ? "enabled" : "disabled")} for the '{account}' account.");
+            }
+        }
+    }
+}

--- a/examples/ConsoleApp/appsettings.json
+++ b/examples/ConsoleApp/appsettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "FeatureManagement": {
+    "Beta": {
+      "EnabledFor": [
+        {
+          "Name": "AccountId",
+          "Parameters": {
+            "AllowedAccounts": [ "abcdefghijklmnopqrstuvwxyz" ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
+++ b/src/Microsoft.FeatureManagement/ContextualFeatureFilterEvaluator.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Provides a performance efficient method of evaluating IContextualFeatureFilter&lt;T&gt; without knowing what the generic type parameter is.
+    /// </summary>
+    class ContextualFeatureFilterEvaluator : IContextualFeatureFilter<object>
+    {
+        private IFeatureFilterMetadata _filter;
+        private Func<object, FeatureFilterEvaluationContext, object, Task<bool>> _evaluateFunc;
+
+        public ContextualFeatureFilterEvaluator(IFeatureFilterMetadata filter, Type appContextType)
+        {
+            if (filter == null)
+            {
+                throw new ArgumentNullException(nameof(filter));
+            }
+
+            if (appContextType == null)
+            {
+                throw new ArgumentNullException(nameof(appContextType));
+            }
+
+            Type targetInterface = GetContextualFilterInterface(filter, appContextType);
+
+            //
+            // Extract IContextualFeatureFilter<T>.EvaluateAsync method.
+            if (targetInterface != null)
+            {
+                MethodInfo evaluateMethod = targetInterface.GetMethod(nameof(IContextualFeatureFilter<object>.EvaluateAsync), BindingFlags.Public | BindingFlags.Instance);
+
+                _evaluateFunc = TypeAgnosticEvaluate(filter.GetType(), evaluateMethod);
+            }
+
+            _filter = filter;
+        }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext evaluationContext, object context)
+        {
+            if (_evaluateFunc == null)
+            {
+                return Task.FromResult(false);
+            }
+
+            return _evaluateFunc(_filter, evaluationContext, context);
+        }
+
+        public static bool IsContextualFilter(IFeatureFilterMetadata filter, Type appContextType)
+        {
+            return GetContextualFilterInterface(filter, appContextType) != null;
+        }
+
+        private static Type GetContextualFilterInterface(IFeatureFilterMetadata filter, Type appContextType)
+        {
+            IEnumerable<Type> contextualFilterInterfaces = filter.GetType().GetInterfaces().Where(i => i.IsGenericType && i.GetGenericTypeDefinition().IsAssignableFrom(typeof(IContextualFeatureFilter<>)));
+
+            Type targetInterface = null;
+
+            if (contextualFilterInterfaces != null)
+            {
+                targetInterface = contextualFilterInterfaces.FirstOrDefault(i => i.GetGenericArguments()[0].IsAssignableFrom(appContextType));
+            }
+
+            return targetInterface;
+        }
+
+        private static Func<object, FeatureFilterEvaluationContext, object, Task<bool>> TypeAgnosticEvaluate(Type filterType, MethodInfo method)
+        {
+            //
+            // Get the generic version of the evaluation helper method
+            MethodInfo genericHelper = typeof(ContextualFeatureFilterEvaluator).GetMethod(nameof(GenericTypeAgnosticEvaluate),
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            //
+            // Create a type specific version of the evaluation helper method
+            MethodInfo constructedHelper = genericHelper.MakeGenericMethod
+                (filterType, method.GetParameters()[0].ParameterType, method.GetParameters()[1].ParameterType, method.ReturnType);
+
+            //
+            // Invoke the method to get the func
+            object typeAgnosticDelegate = constructedHelper.Invoke(null, new object[] { method });
+
+            return (Func<object, FeatureFilterEvaluationContext, object, Task<bool>>)typeAgnosticDelegate;
+        }
+
+        private static Func<object, FeatureFilterEvaluationContext, object, Task<bool>> GenericTypeAgnosticEvaluate<TTarget, TParam1, TParam2, TReturn>(MethodInfo method)
+        {
+            Func<TTarget, FeatureFilterEvaluationContext, TParam2, Task<bool>> func = (Func<TTarget, FeatureFilterEvaluationContext, TParam2, Task<bool>>)Delegate.CreateDelegate
+                (typeof(Func<TTarget, FeatureFilterEvaluationContext, TParam2, Task<bool>>), method);
+
+            Func<object, FeatureFilterEvaluationContext, object, Task<bool>> genericDelegate = (object target, FeatureFilterEvaluationContext param1, object param2) => func((TTarget)target, param1, (TParam2)param2);
+
+            return genericDelegate;
+        }
+    }
+}

--- a/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
+++ b/src/Microsoft.FeatureManagement/FeatureManagerSnapshot.cs
@@ -35,5 +35,21 @@ namespace Microsoft.FeatureManagement
 
             return enabled;
         }
+
+        public async Task<bool> IsEnabledAsync<TContext>(string feature, TContext context)
+        {
+            //
+            // First, check local cache
+            if (_flagCache.ContainsKey(feature))
+            {
+                return _flagCache[feature];
+            }
+
+            bool enabled = await _featureManager.IsEnabledAsync(feature, context).ConfigureAwait(false);
+
+            _flagCache[feature] = enabled;
+
+            return enabled;
+        }
     }
 }

--- a/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IContextualFeatureFilter.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using System.Threading.Tasks;
+
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// A filter that can be used to determine whether some criteria is met to enable a feature. A feature filter is free to use any criteria available, such as process state or request content.
+    /// Feature filters can be registered for a given feature and if any feature filter evaluates to true, that feature will be considered enabled.
+    /// A contextual feature filter can take advantage of contextual data passed in from callers of the feature management system.
+    /// A contextual feature filter will only be executed if a context that is assignable from TContext is available.
+    /// </summary>
+    public interface IContextualFeatureFilter<TContext> : IFeatureFilterMetadata
+    {
+        /// <summary>
+        /// Evalutates the feature filter to see if the filter's criteria for being enabled has been satisfied.
+        /// </summary>
+        /// <param name="featureFilterContext">A feature filter evaluation context that contains information that may be needed to evalute the filter. This context includes configuration, if any, for this filter for the feature being evaluated.</param>
+        /// <param name="appContext">A context defined by the application that is passed in to the feature management system to provide contextual information for evaluating a feature's state.</param>
+        /// <returns>True if the filter's criteria has been met, false otherwise.</returns>
+        Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, TContext appContext);
+    }
+}

--- a/src/Microsoft.FeatureManagement/IFeatureFilter.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.FeatureManagement
     /// <summary>
     /// A filter that can be used to determine whether some criteria is met to enable a feature. A feature filter is free to use any criteria available, such as process state or request content. Feature filters can be registered for a given feature and if any feature filter evaluates to true, that feature will be considered enabled.
     /// </summary>
-    public interface IFeatureFilter
+    public interface IFeatureFilter : IFeatureFilterMetadata
     {
         /// <summary>
         /// Evalutates the feature filter to see if the filter's criteria for being enabled has been satisfied.

--- a/src/Microsoft.FeatureManagement/IFeatureFilterMetadata.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureFilterMetadata.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Microsoft.FeatureManagement
+{
+    /// <summary>
+    /// Marker interface for feature filters used to evaluate the state of a feature
+    /// </summary>
+    public interface IFeatureFilterMetadata
+    {
+    }
+}

--- a/src/Microsoft.FeatureManagement/IFeatureManagementBuilder.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManagementBuilder.cs
@@ -17,10 +17,12 @@ namespace Microsoft.FeatureManagement
 
         /// <summary>
         /// Adds a given feature filter to the list of feature filters that will be available to enable features during runtime.
+        /// Possible feature filter metadata types include <see cref="IFeatureFilter"/> and <see cref="IContextualFeatureFilter{TContext}"/>
+        /// Only one feature filter interface can be implemented by a single type.
         /// </summary>
         /// <typeparam name="T">The feature filter type.</typeparam>
         /// <returns>The feature management builder.</returns>
-        IFeatureManagementBuilder AddFeatureFilter<T>() where T : IFeatureFilter;
+        IFeatureManagementBuilder AddFeatureFilter<T>() where T : IFeatureFilterMetadata;
 
         /// <summary>
         /// Adds an <see cref="ISessionManager"/> to be used for storing feature state in a session.

--- a/src/Microsoft.FeatureManagement/IFeatureManager.cs
+++ b/src/Microsoft.FeatureManagement/IFeatureManager.cs
@@ -16,5 +16,13 @@ namespace Microsoft.FeatureManagement
         /// <param name="feature">The name of the feature to check.</param>
         /// <returns>True if the feature is enabled, otherwise false.</returns>
         Task<bool> IsEnabledAsync(string feature);
+
+        /// <summary>
+        /// Checks whether a given feature is enabled.
+        /// </summary>
+        /// <param name="feature">The name of the feature to check.</param>
+        /// <param name="context">A context providing information that can be used to evaluate whether a feature should be on or off.</param>
+        /// <returns>True if the feature is enabled, otherwise false.</returns>
+        Task<bool> IsEnabledAsync<TContext>(string feature, TContext context);
     }
 }

--- a/tests/Tests.FeatureManagement/AppContext.cs
+++ b/tests/Tests.FeatureManagement/AppContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Tests.FeatureManagement
+{
+    class AppContext : IAccountContext
+    {
+        public string AccountId { get; set; }
+    }
+}

--- a/tests/Tests.FeatureManagement/ContextualTestFilter.cs
+++ b/tests/Tests.FeatureManagement/ContextualTestFilter.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.FeatureManagement;
+using System;
+using System.Threading.Tasks;
+
+namespace Tests.FeatureManagement
+{
+    class ContextualTestFilter : IContextualFeatureFilter<IAccountContext>
+    {
+        public Func<FeatureFilterEvaluationContext, IAccountContext, bool> ContextualCallback { get; set; }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
+        {
+            return Task.FromResult(ContextualCallback?.Invoke(context, accountContext) ?? false);
+        }
+    }
+}

--- a/tests/Tests.FeatureManagement/FeatureManagement.cs
+++ b/tests/Tests.FeatureManagement/FeatureManagement.cs
@@ -45,7 +45,7 @@ namespace Tests.FeatureManagement
 
             Assert.False(await featureManager.IsEnabledAsync(OffFeature));
 
-            IEnumerable<IFeatureFilter> featureFilters = serviceProvider.GetRequiredService<IEnumerable<IFeatureFilter>>();
+            IEnumerable<IFeatureFilterMetadata> featureFilters = serviceProvider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>();
 
             //
             // Sync filter
@@ -98,7 +98,7 @@ namespace Tests.FeatureManagement
                 app.UseMvc();
             }));
 
-            IEnumerable<IFeatureFilter> featureFilters = testServer.Host.Services.GetRequiredService<IEnumerable<IFeatureFilter>>();
+            IEnumerable<IFeatureFilterMetadata> featureFilters = testServer.Host.Services.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>();
 
             TestFilter testFeatureFilter = (TestFilter)featureFilters.First(f => f is TestFilter);
 
@@ -133,7 +133,7 @@ namespace Tests.FeatureManagement
             })
             .Configure(app => app.UseMvc()));
 
-            IEnumerable<IFeatureFilter> featureFilters = testServer.Host.Services.GetRequiredService<IEnumerable<IFeatureFilter>>();
+            IEnumerable<IFeatureFilterMetadata> featureFilters = testServer.Host.Services.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>();
 
             TestFilter testFeatureFilter = (TestFilter)featureFilters.First(f => f is TestFilter);
 
@@ -237,6 +237,65 @@ namespace Tests.FeatureManagement
             }
 
             Assert.True(enabledCount > 0 && enabledCount < 10);
+        }
+
+        [Fact]
+        public async Task UsesContext()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            var serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddSingleton(config)
+                .AddFeatureManagement()
+                .AddFeatureFilter<ContextualTestFilter>();
+
+            ServiceProvider provider = serviceCollection.BuildServiceProvider();
+
+            ContextualTestFilter contextualTestFeatureFilter = (ContextualTestFilter)provider.GetRequiredService<IEnumerable<IFeatureFilterMetadata>>().First(f => f is ContextualTestFilter);
+
+            contextualTestFeatureFilter.ContextualCallback = (ctx, accountContext) =>
+            {
+                var allowedAccounts = new List<string>();
+
+                ctx.Parameters.Bind("AllowedAccounts", allowedAccounts);
+
+                return allowedAccounts.Contains(accountContext.AccountId);
+            };
+
+            IFeatureManager featureManager = provider.GetRequiredService<IFeatureManager>();
+
+            AppContext context = new AppContext();
+
+            context.AccountId = "NotEnabledAccount";
+
+            Assert.False(await featureManager.IsEnabledAsync(ConditionalFeature, context));
+
+            context.AccountId = "abc";
+
+            Assert.True(await featureManager.IsEnabledAsync(ConditionalFeature, context));
+        }
+
+        [Fact]
+        public void LimitsFeatureFilterImplementations()
+        {
+            IConfiguration config = new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
+
+            var serviceCollection = new ServiceCollection();
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new ServiceCollection().AddSingleton(config)
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<InvalidFeatureFilter>();
+            });
+
+            Assert.Throws<ArgumentException>(() =>
+            {
+                new ServiceCollection().AddSingleton(config)
+                    .AddFeatureManagement()
+                    .AddFeatureFilter<InvalidFeatureFilter2>();
+            });
         }
     }
 }

--- a/tests/Tests.FeatureManagement/IAccountContext.cs
+++ b/tests/Tests.FeatureManagement/IAccountContext.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+namespace Tests.FeatureManagement
+{
+    interface IAccountContext
+    {
+        string AccountId { get; }
+    }
+}

--- a/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
+++ b/tests/Tests.FeatureManagement/InvalidFeatureFilter.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+//
+using Microsoft.FeatureManagement;
+using System.Threading.Tasks;
+
+namespace Tests.FeatureManagement
+{
+    //
+    // Cannot implement more than one IFeatureFilter interface
+    class InvalidFeatureFilter : IContextualFeatureFilter<IAccountContext>, IContextualFeatureFilter<object>
+    {
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context, IAccountContext accountContext)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext)
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    //
+    // Cannot implement more than one IFeatureFilter interface
+    class InvalidFeatureFilter2 : IFeatureFilter, IContextualFeatureFilter<object>
+    {
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext featureFilterContext, object appContext)
+        {
+            return Task.FromResult(false);
+        }
+
+        public Task<bool> EvaluateAsync(FeatureFilterEvaluationContext context)
+        {
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/tests/Tests.FeatureManagement/appsettings.json
+++ b/tests/Tests.FeatureManagement/appsettings.json
@@ -16,6 +16,14 @@
           "Parameters": {
             "P1": "V1"
           }
+        },
+        {
+          "Name": "ContextualTest",
+          "Parameters": {
+            "AllowedAccounts": [
+              "abc"
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
…is enabled. (#14)

* Added the capability to pass in a context when checking if a feature is enabled. This enables applications that do not flow an ambient context to access contextual information when evaluating whether a feature should be enabled.

* Updated readme to provide contextual feature filter guidance.

* Refactored code in Feature Manager and ContextualFeatureFilterEvaluator for readability.

* Updated feature management builder such that a feature filter that implements more than a single feature filter interface cannot be added.

* Remove code used for debugging.

* Updated account id filter to use a proper variable name.